### PR TITLE
feat: Add interactive share handler page

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,7 +26,7 @@
   "lang": "ja",
   "dir": "ltr",
   "share_target": {
-    "action": "/share-target.html",
+    "action": "/share-handler.html",
     "method": "GET",
     "params": {
       "title": "title",

--- a/public/share-handler.html
+++ b/public/share-handler.html
@@ -75,15 +75,16 @@
         function createPost() {
             const { title, text, url } = getSharedContent();
             
-            // 投稿作成ページにデータを渡す（実装は既存のアプリケーションに合わせて調整が必要）
-            const postData = {
-                title: title,
-                content: text + (url ? '\n\n参照: ' + url : '')
+            const shareData = {
+                url: url || '',
+                title: title || '',
+                text: text || '',
+                timestamp: Date.now()
             };
             
-            // セッションストレージに保存してホームページに移動
-            sessionStorage.setItem('sharedPostData', JSON.stringify(postData));
-            window.location.href = '/';
+            // localStorageに保存してホームページに移動
+            localStorage.setItem('pendingShare', JSON.stringify(shareData));
+            window.location.href = '/?shared=true';
         }
         
         // ページ読み込み時にコンテンツを表示


### PR DESCRIPTION
Introduces an interactive share handler page (`share-handler.html`) to replace the previous direct-to-form behavior.

When a user shares a URL to the application, they are now shown a dedicated page that displays the shared information (URL, title, text).

From this new page, the user can choose to proceed by clicking a "Create as Post" button. This action saves the shared data to localStorage and redirects to the main application, where the new post form is then pre-filled with the information, preserving the existing workflow.

This change directly addresses the user's request for a new URL sharing page that is displayed before the new post page.