### PR TITLE
feat: Rebuild share handling via URL parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,21 +192,30 @@ const PostForm = ({ onPostAdded }) => {
     const shareTitle = params.get('share_title');
     const shareText = params.get('share_text');
 
-    if (shareUrl) {
-      // スマートURL検出ロジックをここでも適用
-      let detectedUrl = shareUrl;
-      let detectedContent = shareText || shareTitle || '';
+    if (shareUrl || shareTitle || shareText) {
+      let detectedUrl = shareUrl || '';
+      let detectedContent = '';
 
-      if (!detectedUrl && isURL(shareText)) {
+      // 優先順位1: share_url パラメータ
+      if (isURL(shareUrl)) {
+        detectedUrl = shareUrl;
+        detectedContent = shareText || shareTitle || '';
+      }
+      // 優先順位2: share_text パラメータがURLの場合
+      else if (isURL(shareText)) {
         detectedUrl = shareText;
         detectedContent = shareTitle || '';
+      }
+      // 優先順位3: 上記以外
+      else {
+        detectedContent = shareText || shareTitle || '';
       }
 
       setUrl(detectedUrl);
       setOriginalContent(detectedContent);
+      setSummary(detectedContent); // UX改善：サマリーにも同じ内容をセット
 
       // 共有コンテンツがある場合、投稿タブをアクティブにする
-      // Appコンポーネントに通知する必要がある
       window.dispatchEvent(new CustomEvent('activateCreateTab'));
 
       // URLからクエリパラメータを削除して、リロード時に再実行されないようにする


### PR DESCRIPTION
Refactors the entire Web Share Target handling mechanism. This change is based on user feedback and resolves several issues with the previous implementation, including caching problems and incorrect data flow.

The new implementation features:
- An interactive `/share-handler.html` page that is displayed when content is shared to the app. This page shows the user the content that was shared (URL, title, text).
- A "Create Post" button on the handler page that redirects to the main application, passing the shared data as URL query parameters (e.g., `?share_url=...`).
- New logic in the main application (`index.html`) that reads these URL parameters on page load, populates the new post form (for both URL and content), switches to the "New Post" tab, and cleans the URL to prevent re-triggering on refresh.
- The old, confusing data transfer mechanisms using `localStorage` and `sessionStorage` have been removed.
- The service worker has been updated to correctly cache all necessary assets for the new flow.

This new approach is more robust, easier to debug, and directly implements the user's request for an interactive intermediate page for shared content.