### PR TITLE
fix: Service Workerのキャッシュバージョンを更新

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ai-tech-hub-v2'; // バージョンを更新してキャッシュをリフレッシュ
+const CACHE_NAME = 'ai-tech-hub-v3'; // バージョンを更新してキャッシュをリフレッシュ
 const OFFLINE_URL = '/';
 
 // キャッシュするリソース


### PR DESCRIPTION
ユーザー環境で修正が反映されない問題を解決するため、Service Workerのキャッシュバージョンをv2からv3に更新しました。

これにより、ブラウザは新しいService Workerをインストールし、古いキャッシュ（修正前のindex.htmlを含む）が破棄されるため、フォームのバリデーション問題が解決されるはずです。