### PR TITLE
fix: vercel.jsonから削除済みAPIへの参照を削除

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -22,9 +22,6 @@
     "api/analyze-labels.mjs": {
       "memory": 256
     },
-    "api/preview.mjs": {
-      "memory": 128
-    },
     "api/admin-login.mjs": {
       "memory": 128
     },


### PR DESCRIPTION
前のコミットで `/api/preview.mjs` サーバーレス関数を削除しましたが、`vercel.json` 設定ファイルから対応する定義を削除していませんでした。

これにより、設定が存在しないファイルを指してしまい、デプロイエラーが発生していました。

このコミットでは、`vercel.json` から古いエントリを削除し、デプロイの問題を解決します。