### PR TITLE
feat: 過去の投稿にプレビューを生成するデータ移行スクリプトを追加

### DIFF
--- a/data/posts.json
+++ b/data/posts.json
@@ -20,7 +20,14 @@
       "2025-06-30": 1,
       "2025-06-29": 1
     },
-    "recentViewCount": 4
+    "recentViewCount": 4,
+    "previewData": {
+      "title": "Genspark (ジェンスパーク) : 日本公式 (@genspark_japan) on X",
+      "description": "🎬 Gensparkに新しい動画モデルが5つも追加されたよ！\nなんと今、Gensparkでは【16種類】もの動画モデルから好きに選べるんだ✨\nしかも無料ユーザーでも毎日【200クレジット】もらえる！\n今日からキミも、Gensparkで自分だけの傑作動画を作ってみない？\nスタートはこちら👉 https://t.co/ldhwXzK6q8",
+      "image": "https://pbs.twimg.com/amplify_video_thumb/1938164672735416320/img/L5t0y32nnm7OMu09.jpg:large",
+      "siteName": "X (formerly Twitter)",
+      "url": "https://x.com/genspark_japan/status/1938175412863164522"
+    }
   },
   {
     "id": "post_1750929070515",
@@ -43,6 +50,13 @@
       "2025-06-30": 2,
       "2025-06-29": 1
     },
-    "recentViewCount": 6
+    "recentViewCount": 6,
+    "previewData": {
+      "title": "まつにぃ (@yugen_matuni) on X",
+      "description": "Gemini CLI見てると、もう世の中で流行ったものは1ヶ月以内に爆速で再構築され、しかもOSSレベルで公開される脅威のスピード感な世界になってますね。\n\nイカれた世界になってきて、これがまだ2025年の真ん中という恐怖。\n\nあと半年でどこまで伸びるのか...",
+      "image": "https://pbs.twimg.com/profile_images/1785991886655852544/Q5mmBVtu_200x200.jpg",
+      "siteName": "X (formerly Twitter)",
+      "url": "https://x.com/yugen_matuni/status/1937955160262905938"
+    }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "npm run build:css:prod",
     "build:css": "tailwindcss -i ./src/input.css -o ./public/dist/output.css --watch",
-    "build:css:prod": "tailwindcss -i ./src/input.css -o ./public/dist/output.css --minify"
+    "build:css:prod": "tailwindcss -i ./src/input.css -o ./public/dist/output.css --minify",
+    "backfill:previews": "node scripts/backfill-previews.mjs"
   }
 }

--- a/scripts/backfill-previews.mjs
+++ b/scripts/backfill-previews.mjs
@@ -1,0 +1,106 @@
+import { kv } from '@vercel/kv';
+import { isKvAvailable } from '../api/utils/kv-utils.mjs';
+import { generatePreviewData } from '../api/utils/preview-utils.mjs';
+import fs from 'fs/promises';
+import path from 'path';
+
+const POSTS_FILE = path.join(process.cwd(), 'data', 'posts.json');
+
+// --- Data Loading ---
+async function getAllPosts() {
+  if (isKvAvailable()) {
+    console.log('Vercel KVから投稿を読み込んでいます...');
+    const postsJson = await kv.lrange('posts', 0, -1);
+    // KVからのデータはJSON文字列なのでパースが必要
+    return postsJson.map(p => JSON.parse(p));
+  } else {
+    console.log('ローカルのJSONファイルから投稿を読み込んでいます...');
+    try {
+      const data = await fs.readFile(POSTS_FILE, 'utf-8');
+      return JSON.parse(data);
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        return []; // ファイルがない場合は空配列
+      }
+      throw error;
+    }
+  }
+}
+
+// --- Data Saving ---
+async function saveAllPosts(posts) {
+  if (isKvAvailable()) {
+    console.log('Vercel KVに投稿を保存しています...');
+    // KVではリストを一度クリアして、更新されたリストを再プッシュするのが一般的
+    const pipeline = kv.pipeline();
+    pipeline.del('posts');
+    for (const post of posts) {
+      // 保存する前に再度JSON文字列に変換
+      pipeline.lpush('posts', JSON.stringify(post));
+    }
+    await pipeline.exec();
+  } else {
+    console.log('ローカルのJSONファイルに投稿を保存しています...');
+    const dataDir = path.dirname(POSTS_FILE);
+    try {
+      await fs.access(dataDir);
+    } catch {
+      await fs.mkdir(dataDir, { recursive: true });
+    }
+    await fs.writeFile(POSTS_FILE, JSON.stringify(posts, null, 2));
+  }
+}
+
+
+// --- Main Script Logic ---
+async function main() {
+  console.log('🚀 プレビューデータ移行スクリプトを開始します...');
+
+  const allPosts = await getAllPosts();
+  if (allPosts.length === 0) {
+    console.log('投稿が見つかりませんでした。処理を終了します。');
+    return;
+  }
+
+  console.log(`取得した投稿数: ${allPosts.length}件`);
+
+  let updatedCount = 0;
+  const updatedPosts = [];
+
+  for (const post of allPosts) {
+    // `previewData`フィールドが存在しない、またはnullの場合に処理
+    if (post.previewData === undefined || post.previewData === null) {
+      console.log(`\n📝 投稿ID: ${post.id} のプレビューを生成します...`);
+      console.log(`   URL: ${post.url}`);
+      try {
+        const previewData = await generatePreviewData(post.url);
+        post.previewData = previewData;
+        console.log(`   ✅ プレビュー生成成功: ${previewData.title}`);
+        updatedCount++;
+      } catch (error) {
+        console.error(`   ❌ プレビュー生成失敗: ${error.message}`);
+        // 失敗した場合は post.previewData は変更されない
+      }
+    } else {
+      console.log(`\n⏭️ 投稿ID: ${post.id} は既にプレビューデータを持っています。スキップします。`);
+    }
+    updatedPosts.push(post);
+  }
+
+  if (updatedCount > 0) {
+    console.log(`\n💾 ${updatedCount}件の投稿を更新しました。データベースに保存しています...`);
+    // 投稿は新しい順に保存されるべきなので、createdAtでソートし直す
+    updatedPosts.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    await saveAllPosts(updatedPosts);
+    console.log('✅ 保存が完了しました。');
+  } else {
+    console.log('\n✨ 更新する投稿はありませんでした。');
+  }
+
+  console.log('🎉 移行スクリプトが正常に完了しました。');
+}
+
+main().catch(error => {
+  console.error('\n🚨 スクリプトの実行中に致命的なエラーが発生しました:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
新しいプレビュー生成システムが導入される前に作成された投稿でプレビューが表示されない問題に対処するため、データ移行用のスクリプトを追加します。

- `scripts/backfill-previews.mjs`: 全ての投稿をスキャンし、プレビューデータが存在しない投稿に対してデータを生成・追加するスクリプトです。
- `package.json`: スクリプトを簡単に実行できるよう `backfill:previews` というnpmスクリプトを追加しました。
- `data/posts.json`: このスクリプトを実行し、既存の投稿にプレビューデータを追加しました。

これにより、過去の投稿と新しい投稿の両方でプレビューが利用可能になり、一貫したユーザー体験が提供されます。