### PR TITLE
fix: 新規投稿後にプレビューコンポーネントが更新されるように修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -364,6 +364,10 @@ const PostCard = ({ post, isAdmin, onDelete, onPostUpdated }) => {
     const [commentStatus, setCommentStatus] = useState({ loading: false, error: null });
     const [currentPreviewData, setCurrentPreviewData] = useState(post.previewData);
 
+    useEffect(() => {
+        setCurrentPreviewData(post.previewData);
+    }, [post.previewData]);
+
     // 閲覧数をインクリメント（URLクリック時のみ）
     const incrementViewCount = async () => {
         try {


### PR DESCRIPTION
新規投稿を作成した後、ページをリフレッシュするまでURLプレビューが表示されない問題を解決します。

問題の原因は、`PostCard`コンポーネントが受け取る `post` プロパティが更新された後も、プレビューデータを保持する内部のstateが追従していなかったことでした。

`PostCard`コンポーネントに `useEffect` フックを追加することでこの問題を修正しました。このフックは `post.previewData` の変更を監視し、コンポーネントの内部stateを適切に更新します。これにより、プレビューは常にコンポーネントに渡された最新のデータと同期されるようになります。