### PR TITLE
debug: Add detailed logging to create-post API

### DIFF
--- a/api/create-post.mjs
+++ b/api/create-post.mjs
@@ -248,8 +248,19 @@ export default async function handler(request, response) {
     console.log('Creating post with data:', newPost);
 
     try {
+      console.log('--- DIAGNOSTIC LOG ---');
+      console.log('Preparing to save post. Full object:');
+      console.log(JSON.stringify(newPost, null, 2));
+      console.log('Checking types of newPost properties:');
+      for (const key in newPost) {
+        console.log(`- ${key}: ${typeof newPost[key]}`);
+      }
+      const postJsonString = JSON.stringify(newPost);
+      console.log('Stringified JSON to be sent:');
+      console.log(postJsonString);
+      console.log('--- END DIAGNOSTIC LOG ---');
+
       if (isKvAvailable()) {
-        const postJsonString = JSON.stringify(newPost);
         await kv.lpush('posts', postJsonString);
         console.log('KVに保存された投稿:', postJsonString);
       } else {


### PR DESCRIPTION
This change is for diagnostic purposes to investigate a persistent 500 error in the production environment.

- Adds detailed logging before the database write operation in `api/create-post.mjs`.
- Logs the full post object, the type of each property, and the final JSON string being sent to the database.

This will help identify if any data is malformed or `undefined` in the Vercel environment, which could be causing the `kv.lpush` command to fail.